### PR TITLE
Turn off spell check for ingredient name

### DIFF
--- a/src/components/Ingredient.vue
+++ b/src/components/Ingredient.vue
@@ -4,6 +4,7 @@
       <span ref="ingredientName" class="ingredient-name-container">
         <TextInput
           class="ingredient-name"
+          spellcheck="false"
           @focus="
             toggleEditor('open');
             setUnderline();


### PR DESCRIPTION
"Levain" was being flagged as mispelled.